### PR TITLE
Fix #211: keep undo states

### DIFF
--- a/src/editor.js
+++ b/src/editor.js
@@ -23,10 +23,11 @@ class MonacoEditor extends React.Component {
       // Consider the situation of rendering 1+ times before the editor mounted
       if (this.editor) {
         this.__prevent_trigger_change_event = true;
+        this.editor.pushUndoStop();
         this.editor.executeEdits('', [{
           range: this.editor.getModel().getFullModelRange(),
           text: this.__current_value
-        }]);
+        }], [new monaco.Range(1, 1, 1, 1)]);
         this.editor.pushUndoStop();
         this.__prevent_trigger_change_event = false;
       }

--- a/src/editor.js
+++ b/src/editor.js
@@ -1,7 +1,7 @@
 import * as monaco from 'monaco-editor/esm/vs/editor/editor.api';
 import PropTypes from 'prop-types';
 import React from 'react';
-import { processSize } from './utils'
+import { processSize } from './utils';
 
 function noop() { }
 
@@ -23,7 +23,10 @@ class MonacoEditor extends React.Component {
       // Consider the situation of rendering 1+ times before the editor mounted
       if (this.editor) {
         this.__prevent_trigger_change_event = true;
-        this.editor.setValue(this.__current_value);
+        this.editor.executeEdits('', [{
+          range: this.editor.getModel().getFullModelRange(),
+          text: this.__current_value
+        }]);
         this.__prevent_trigger_change_event = false;
       }
     }
@@ -40,7 +43,7 @@ class MonacoEditor extends React.Component {
       this.editor.layout();
     }
     if (prevProps.options !== this.props.options) {
-      this.editor.updateOptions(this.props.options)
+      this.editor.updateOptions(this.props.options);
     }
   }
 

--- a/src/editor.js
+++ b/src/editor.js
@@ -27,6 +27,7 @@ class MonacoEditor extends React.Component {
           range: this.editor.getModel().getFullModelRange(),
           text: this.__current_value
         }]);
+        this.editor.pushUndoStop();
         this.__prevent_trigger_change_event = false;
       }
     }


### PR DESCRIPTION
As documented [here](https://microsoft.github.io/monaco-editor/api/interfaces/monaco.editor.icodeeditor.html#executeedits), `executeEdits` is the right way to edit  text while preserving the undo-redo stack. The previous code uses `setValue` which discards the undo-redo stack, preventing undo operations.