### PR TITLE
Check model existence before disposing

### DIFF
--- a/src/diff.js
+++ b/src/diff.js
@@ -115,8 +115,12 @@ class MonacoDiffEditor extends React.Component {
   destroyMonaco() {
     if (this.editor) {
       const { original, modified } = this.editor.getModel();
-      original.dispose();
-      modified.dispose();
+      if (original) {
+        original.dispose();
+      }
+      if (modified) {
+        modified.dispose();
+      } 
       this.editor.dispose();
     }
     if (this._subscription) {

--- a/src/editor.js
+++ b/src/editor.js
@@ -58,8 +58,11 @@ class MonacoEditor extends React.Component {
 
   destroyMonaco() {
     if (this.editor) {
-      this.editor.getModel().dispose();
       this.editor.dispose();
+      const model = this.editor.getModel();
+      if (model) {
+        model.dispose();
+      }
     }
     if (this._subscription) {
       this._subscription.dispose();


### PR DESCRIPTION
My current project has multiple react-monaco-editors on the same page. Each editor may use multiple models and some share models. I currently reuse models between different editors. When I unmount the editors it creates an error: 
<img width="688" alt="Screen Shot 2019-10-18 at 8 24 49 AM" src="https://user-images.githubusercontent.com/14320597/67107223-e022dd80-f180-11e9-8976-c965e44d08b1.png">

This small change fixes it.