### PR TITLE
Fix crash after diff viewer unmount

### DIFF
--- a/src/diff.js
+++ b/src/diff.js
@@ -114,6 +114,7 @@ class MonacoDiffEditor extends React.Component {
 
   destroyMonaco() {
     if (this.editor) {
+      this.editor.dispose();
       const { original, modified } = this.editor.getModel();
       if (original) {
         original.dispose();
@@ -121,7 +122,6 @@ class MonacoDiffEditor extends React.Component {
       if (modified) {
         modified.dispose();
       }
-      this.editor.dispose();
     }
     if (this._subscription) {
       this._subscription.dispose();


### PR DESCRIPTION
Disposing the model before the editor causes an error after unmounting, after performing an action that pops up a widget like `ctrl + f` 

```
Canceled: Canceled
    at Module.canceled 
    at Delayer../node_modules/monaco-editor/esm/vs/base/common/async.js.Delayer.cancel 
    at Object.dispose 
    at Array.forEach (<anonymous>)
    at dispose 
    at FindWidget../node_modules/monaco-editor/esm/vs/base/common/lifecycle.js.Disposable.dispose 
    at Array.forEach (<anonymous>)
```

The change in https://github.com/react-monaco-editor/react-monaco-editor/pull/253 fixes this for the normal editor, but the same fix needs to be applied to the diff viewer.