### PR TITLE
Move @types/react to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@babel/plugin-proposal-class-properties": "^7.5.5",
     "@babel/preset-env": "^7.5.5",
     "@babel/preset-react": "^7.0.0",
+    "@types/react": "^16.9.2",
     "babel-eslint": "^10.0.3",
     "eslint": "^6.3.0",
     "eslint-config-airbnb": "^18.0.1",
@@ -59,7 +60,6 @@
     "react": "^15.x || ^16.x"
   },
   "dependencies": {
-    "@types/react": "^16.9.2",
     "prop-types": "^15.7.2"
   }
 }


### PR DESCRIPTION
Move @types/react to devDependencies in package.json.

Possibly/partially fixes #256?

I'm still uncertain about whether this will prevent `@types/react` from being included in the distributed NPM package for `react-monaco-editor`