### PR TITLE
fix: @types/react

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@babel/plugin-proposal-class-properties": "^7.7.4",
     "@babel/preset-env": "^7.7.7",
     "@babel/preset-react": "^7.7.4",
+    "@types/react": "^15.x || ^16.x",
     "babel-eslint": "^10.0.3",
     "eslint": "^6.8.0",
     "eslint-config-airbnb": "^18.0.1",
@@ -59,7 +60,6 @@
     "react": "^15.x || ^16.x"
   },
   "dependencies": {
-    "@types/react": "^15.x || ^16.x",
     "prop-types": "^15.7.2"
   }
 }


### PR DESCRIPTION
fix: move @types/react from dependencies into devDependencies

Or if I `yarn add react-monaco-editor` and start my project, an error will throw: 

✖ Compile failed!

[at-loader] ./node_modules/@types/react/index.d.ts:2817:14 
    TS2300: Duplicate identifier 'LibraryManagedAttributes'.

![image](https://user-images.githubusercontent.com/8243326/72232269-f662fd00-35fa-11ea-9062-21f24dd4f221.png)

And I must use `yarn-deduplicate` to deduplicate the @types/react.
The reason is that my node_modules has two version of @types/react, it isn't allowed.