### PR TITLE
Add monaco-editor dependency to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Then open `http://localhost:8886` in a browser.
 ## Installation
 
 ```bash
-yarn add react-monaco-editor
+yarn add react-monaco-editor monaco-editor
 ```
 
 ## Using with Webpack


### PR DESCRIPTION
Since it's required for this package to work..

Fixes https://github.com/react-monaco-editor/react-monaco-editor/issues/272