### PR TITLE
Update options to IStandaloneEditorConstructionOptions

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -63,9 +63,9 @@ export interface MonacoEditorProps extends MonacoEditorBaseProps {
   value?: string | null;
 
   /**
-   * Refer to Monaco interface {monaco.editor.IEditorConstructionOptions}.
+   * Refer to Monaco interface {monaco.editor.IStandaloneEditorConstructionOptions}.
    */
-  options?: monacoEditor.editor.IEditorConstructionOptions;
+  options?: monacoEditor.editor.IStandaloneEditorConstructionOptions;
 
 
   /**


### PR DESCRIPTION
This makes type of options match the monaco editor API for create: https://microsoft.github.io/monaco-editor/api/modules/monaco.editor.html#create. The old types prevented passing some valid options such as `model` or `wordBasedSuggestions`. This change also makes the typings consistent with this change: https://github.com/react-monaco-editor/react-monaco-editor/pull/265