### PR TITLE
Improve dev experience for TypeScript users

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^3.6.0",
     "@typescript-eslint/parser": "^3.6.0",
+    "@types/react": "^16.8.3",
     "eslint": "^7.4.0",
     "eslint-config-airbnb": "^18.2.0",
     "eslint-config-prettier": "^6.11.0",
@@ -46,10 +47,10 @@
     "typescript": "^3.9.6"
   },
   "peerDependencies": {
+    "@types/react": "^16.x",
     "react": "^16.x"
   },
   "dependencies": {
-    "@types/react": "^16.x",
     "monaco-editor": "*",
     "prop-types": "^15.7.2"
   }

--- a/src/diff.tsx
+++ b/src/diff.tsx
@@ -1,6 +1,6 @@
 import * as monaco from "monaco-editor/esm/vs/editor/editor.api";
-import PropTypes from "prop-types";
-import React from "react";
+import * as PropTypes from "prop-types";
+import * as React from "react";
 import { MonacoDiffEditorProps } from "./types";
 import { noop, processSize } from "./utils";
 

--- a/src/editor.tsx
+++ b/src/editor.tsx
@@ -1,6 +1,6 @@
 import * as monaco from "monaco-editor/esm/vs/editor/editor.api";
-import PropTypes from "prop-types";
-import React from "react";
+import * as PropTypes from "prop-types";
+import * as React from "react";
 import { MonacoEditorProps } from "./types";
 import { noop, processSize } from "./utils";
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,6 @@
 {
   "compilerOptions": {
-    "allowSyntheticDefaultImports": true,
     "declaration": true,
-    "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "jsx": "react",
     "module": "esnext",

--- a/yarn.lock
+++ b/yarn.lock
@@ -63,13 +63,13 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
   integrity sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==
 
-"@types/react@^16.x":
-  version "16.9.42"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.42.tgz#9776508d59c1867bbf9bd7f036dab007fdaa1cb7"
-  integrity sha512-iGy6HwfVfotqJ+PfRZ4eqPHPP5NdPZgQlr0lTs8EfkODRBV9cYy8QMKcC9qPCe1JrESC1Im6SrCFR6tQgg74ag==
+"@types/react@^16.8.3":
+  version "16.9.46"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.46.tgz#f0326cd7adceda74148baa9bff6e918632f5069e"
+  integrity sha512-dbHzO3aAq1lB3jRQuNpuZ/mnu+CdD3H0WVaaBQA8LTT3S33xhVBUj232T8M3tAhSWJs/D/UqORYUlJNl/8VQZg==
   dependencies:
     "@types/prop-types" "*"
-    csstype "^2.2.0"
+    csstype "^3.0.2"
 
 "@typescript-eslint/eslint-plugin@^3.6.0":
   version "3.6.0"
@@ -330,10 +330,10 @@ cross-spawn@^7.0.2:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-csstype@^2.2.0:
-  version "2.6.11"
-  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.11.tgz#452f4d024149ecf260a852b025e36562a253ffc5"
-  integrity sha512-l8YyEC9NBkSm783PFTvh0FmJy7s5pFKrDp49ZL7zBGX3fWkO+N4EEyan1qqp8cwPLDcD0OSdyY6hAMoxp34JFw==
+csstype@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.2.tgz#ee5ff8f208c8cd613b389f7b222c9801ca62b3f7"
+  integrity sha512-ofovWglpqoqbfLNOTBNZLSbMuGrblAf1efvvArGKOZMBrIoJeu5UsAipQolkijtyQx5MtAzT/J9IHj/CEY1mJw==
 
 damerau-levenshtein@^1.0.6:
   version "1.0.6"


### PR DESCRIPTION
We're adopting `react-monaco-editor`. First of all, thanks! It's been a blast to use and solved a lot of quirks we had manually integrating Monaco into a React app.

We had some trouble due to the way the TS bindings are set up, however. I understand the JS->TS move is relatively recent so maybe these are just quirks that need to be ironed out? Let me know if any of the changes I'm proposing here are stupid or break something else I hadn't expected :-)

1. Fix react/prop-types imports. Without this PR, TypeScript users of react-monaco-editor would need to have allowSyntheticDefaultImports to be on in their tsconfig, or there would be TS errors due to the way React was being imported. As far as I can tell, simply moving those lines to `import * as React` was all that's needed to make it all work without these settings. This should make adoption easier for TS users.
2. Remove `@types/react` from dependencies. This avoids type clashes if the user has a different version if @types/react.
This matches what common TS definitions do, eg those for [react-redux](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/react-redux) or [react-router](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/react-router) do not have a dependency on @types/react either, and simply assume that the user has this already (in fact, @types/react-router has no dependencies at all). I think we can safely do the same.

Wrt testing, I ran the examples, which worked, and I ran `yarn build` and inspected the output. Not sure how to further test.