### PR TITLE
Fix description of property height

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -30,7 +30,7 @@ export interface MonacoEditorBaseProps {
   width?: string | number;
 
   /**
-   * Height of editor. Defaults to 500.
+   * Height of editor. Defaults to 100%.
    */
   height?: string | number;
 


### PR DESCRIPTION
The description of the property height is not matching the default value set which is `100%`. As shows [in this line of code](https://github.com/react-monaco-editor/react-monaco-editor/blob/d16df27a0da0819168c3b349ae237fa1035aedec/src/editor.tsx#L24).

I do not know if the decision of the default value was initially `500` or `100%` so I decided to make the change on the description and maybe open a discussion about it.