### PR TITLE
Allow users to choose the editor's behavior on value prop change

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-monaco-editor",
-  "version": "0.41.3",
+  "version": "0.41.2",
   "description": "Monaco Editor for React",
   "main": "lib/index.js",
   "module": "lib/index",
@@ -9,8 +9,8 @@
     "preversion": "npm run lint",
     "build": "tsc",
     "clean": "rimraf lib",
-    "format": "eslint --fix {src,example}/**/*.{ts,tsx}",
-    "lint": "eslint {src,example}/**/*.{ts,tsx}",
+    "format": "eslint --fix '{src,example}/**/*.{ts,tsx}'",
+    "lint": "eslint '{src,example}/**/*.{ts,tsx}'",
     "prepublishOnly": "npm run lint && npm run build"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-monaco-editor",
-  "version": "0.41.2",
+  "version": "0.41.3",
   "description": "Monaco Editor for React",
   "main": "lib/index.js",
   "module": "lib/index",
@@ -9,8 +9,8 @@
     "preversion": "npm run lint",
     "build": "tsc",
     "clean": "rimraf lib",
-    "format": "eslint --fix '{src,example}/**/*.{ts,tsx}'",
-    "lint": "eslint '{src,example}/**/*.{ts,tsx}'",
+    "format": "eslint --fix {src,example}/**/*.{ts,tsx}",
+    "lint": "eslint {src,example}/**/*.{ts,tsx}",
     "prepublishOnly": "npm run lint && npm run build"
   },
   "keywords": [

--- a/src/editor.tsx
+++ b/src/editor.tsx
@@ -17,6 +17,7 @@ class MonacoEditor extends React.Component<MonacoEditorProps> {
     editorDidMount: PropTypes.func,
     editorWillMount: PropTypes.func,
     onChange: PropTypes.func,
+    selectChangedValue: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -31,6 +32,7 @@ class MonacoEditor extends React.Component<MonacoEditorProps> {
     editorDidMount: noop,
     editorWillMount: noop,
     onChange: noop,
+    selectChangedValue: true,
   };
 
   editor?: monaco.editor.IStandaloneCodeEditor;
@@ -59,17 +61,21 @@ class MonacoEditor extends React.Component<MonacoEditorProps> {
     if (this.props.value != null && this.props.value !== model.getValue()) {
       this.__prevent_trigger_change_event = true;
       this.editor.pushUndoStop();
-      // pushEditOperations says it expects a cursorComputer, but doesn't seem to need one.
-      // @ts-expect-error
-      model.pushEditOperations(
-        [],
-        [
-          {
-            range: model.getFullModelRange(),
-            text: value,
-          },
-        ]
-      );
+      if (this.props.selectChangedValue) {
+        // pushEditOperations says it expects a cursorComputer, but doesn't seem to need one.
+        // @ts-expect-error
+        model.pushEditOperations(
+          [],
+          [
+            {
+              range: model.getFullModelRange(),
+              text: value,
+            },
+          ]
+        );
+      } else {
+        this.editor.setValue(value);
+      }
       this.editor.pushUndoStop();
       this.__prevent_trigger_change_event = false;
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -84,6 +84,11 @@ export interface MonacoEditorProps extends MonacoEditorBaseProps {
    * An event emitted when the content of the current model has changed.
    */
   onChange?: ChangeHandler;
+
+  /**
+   * A flag which tells if editor content updated via value prop should get selected (default true)
+   */
+  selectChangedValue?: boolean;
 }
 
 // ============ Diff Editor ============


### PR DESCRIPTION
Resolves: #325 

In this PR:
1. Added a prop `selectChangedValue` (bool) which decides between 2 APIs to update the editor's content
2. Bumped patch version (Let me know if versioning needs to be changed differently)

Note: It maintains backward compatibility as the **MonacoEditor** component will default to its current behavior with `value` prop.

_Please let me know if any changes in PR are required._
