### PR TITLE
feat: allow className prop, to set options.extraEditorClassName

### DIFF
--- a/src/diff.tsx
+++ b/src/diff.tsx
@@ -160,7 +160,7 @@ class MonacoDiffEditor extends React.Component<MonacoDiffEditorProps> {
       this.editor = monaco.editor.createDiffEditor(
         this.containerElement,
         {
-          ...prependedOptions,
+          ...(className ? {extraEditorClassName: className} : {}),
           ...options,
           ...(theme ? { theme } : {}),
         },

--- a/src/diff.tsx
+++ b/src/diff.tsx
@@ -143,7 +143,13 @@ class MonacoDiffEditor extends React.Component<MonacoDiffEditorProps> {
   initMonaco() {
     const value =
       this.props.value != null ? this.props.value : this.props.defaultValue;
-    const { original, theme, options, overrideServices, className } = this.props;
+    const {
+      original,
+      theme,
+      options,
+      overrideServices,
+      className,
+    } = this.props;
     if (this.containerElement) {
       // Before initializing monaco editor
       this.editorWillMount();

--- a/src/diff.tsx
+++ b/src/diff.tsx
@@ -97,11 +97,10 @@ class MonacoDiffEditor extends React.Component<MonacoDiffEditorProps> {
       this.editor.layout();
     }
     if (prevProps.options !== options) {
-      const prependedOptions: monaco.editor.IStandaloneEditorConstructionOptions = {};
-      if (className) {
-        prependedOptions.extraEditorClassName = className;
-      }
-      this.editor.updateOptions({ ...prependedOptions, ...options });
+      this.editor.updateOptions({
+        ...(className ? { extraEditorClassName: className } : {}),
+        ...options,
+      });
     }
   }
 
@@ -153,14 +152,10 @@ class MonacoDiffEditor extends React.Component<MonacoDiffEditorProps> {
     if (this.containerElement) {
       // Before initializing monaco editor
       this.editorWillMount();
-      const prependedOptions: monaco.editor.IStandaloneEditorConstructionOptions = {};
-      if (className) {
-        prependedOptions.extraEditorClassName = className;
-      }
       this.editor = monaco.editor.createDiffEditor(
         this.containerElement,
         {
-          ...(className ? {extraEditorClassName: className} : {}),
+          ...(className ? { extraEditorClassName: className } : {}),
           ...options,
           ...(theme ? { theme } : {}),
         },

--- a/src/diff.tsx
+++ b/src/diff.tsx
@@ -18,6 +18,7 @@ class MonacoDiffEditor extends React.Component<MonacoDiffEditorProps> {
     editorDidMount: PropTypes.func,
     editorWillMount: PropTypes.func,
     onChange: PropTypes.func,
+    className: PropTypes.string,
   };
 
   static defaultProps = {
@@ -33,6 +34,7 @@ class MonacoDiffEditor extends React.Component<MonacoDiffEditorProps> {
     editorDidMount: noop,
     editorWillMount: noop,
     onChange: noop,
+    className: null,
   };
 
   editor?: monaco.editor.IStandaloneDiffEditor;
@@ -53,7 +55,7 @@ class MonacoDiffEditor extends React.Component<MonacoDiffEditorProps> {
   }
 
   componentDidUpdate(prevProps: MonacoDiffEditorProps) {
-    const { language, theme, height, options, width } = this.props;
+    const { language, theme, height, options, width, className } = this.props;
 
     const { original, modified } = this.editor.getModel();
 
@@ -95,7 +97,11 @@ class MonacoDiffEditor extends React.Component<MonacoDiffEditorProps> {
       this.editor.layout();
     }
     if (prevProps.options !== options) {
-      this.editor.updateOptions(options);
+      const prependedOptions: monaco.editor.IStandaloneEditorConstructionOptions = {};
+      if (className) {
+        prependedOptions.extraEditorClassName = className;
+      }
+      this.editor.updateOptions({ ...prependedOptions, ...options });
     }
   }
 
@@ -137,13 +143,18 @@ class MonacoDiffEditor extends React.Component<MonacoDiffEditorProps> {
   initMonaco() {
     const value =
       this.props.value != null ? this.props.value : this.props.defaultValue;
-    const { original, theme, options, overrideServices } = this.props;
+    const { original, theme, options, overrideServices, className } = this.props;
     if (this.containerElement) {
       // Before initializing monaco editor
       this.editorWillMount();
+      const prependedOptions: monaco.editor.IStandaloneEditorConstructionOptions = {};
+      if (className) {
+        prependedOptions.extraEditorClassName = className;
+      }
       this.editor = monaco.editor.createDiffEditor(
         this.containerElement,
         {
+          ...prependedOptions,
           ...options,
           ...(theme ? { theme } : {}),
         },

--- a/src/editor.tsx
+++ b/src/editor.tsx
@@ -53,7 +53,15 @@ class MonacoEditor extends React.Component<MonacoEditorProps> {
   }
 
   componentDidUpdate(prevProps: MonacoEditorProps) {
-    const { value, language, theme, height, options, width, className } = this.props;
+    const {
+      value,
+      language,
+      theme,
+      height,
+      options,
+      width,
+      className,
+    } = this.props;
 
     const { editor } = this;
     const model = editor.getModel();

--- a/src/editor.tsx
+++ b/src/editor.tsx
@@ -93,14 +93,13 @@ class MonacoEditor extends React.Component<MonacoEditorProps> {
       editor.layout();
     }
     if (prevProps.options !== options) {
-      const prependedOptions: monaco.editor.IStandaloneEditorConstructionOptions = {};
-      if (className) {
-        prependedOptions.extraEditorClassName = className;
-      }
       // Don't pass in the model on update because monaco crashes if we pass the model
       // a second time. See https://github.com/microsoft/monaco-editor/issues/2027
       const { model: _model, ...optionsWithoutModel } = options;
-      editor.updateOptions({ ...prependedOptions, ...optionsWithoutModel });
+      editor.updateOptions({
+        ...(className ? { extraEditorClassName: className } : {}),
+        ...optionsWithoutModel,
+      });
     }
   }
 
@@ -131,17 +130,13 @@ class MonacoEditor extends React.Component<MonacoEditorProps> {
     const { language, theme, overrideServices, className } = this.props;
     if (this.containerElement) {
       // Before initializing monaco editor
-      const prependedOptions: monaco.editor.IStandaloneEditorConstructionOptions = {};
-      if (className) {
-        prependedOptions.extraEditorClassName = className;
-      }
       const options = { ...this.props.options, ...this.editorWillMount() };
       this.editor = monaco.editor.create(
         this.containerElement,
         {
           value,
           language,
-          ...prependedOptions,
+          ...(className ? { extraEditorClassName: className } : {}),
           ...options,
           ...(theme ? { theme } : {}),
         },

--- a/src/editor.tsx
+++ b/src/editor.tsx
@@ -17,6 +17,7 @@ class MonacoEditor extends React.Component<MonacoEditorProps> {
     editorDidMount: PropTypes.func,
     editorWillMount: PropTypes.func,
     onChange: PropTypes.func,
+    className: PropTypes.string,
   };
 
   static defaultProps = {
@@ -31,6 +32,7 @@ class MonacoEditor extends React.Component<MonacoEditorProps> {
     editorDidMount: noop,
     editorWillMount: noop,
     onChange: noop,
+    className: null,
   };
 
   editor?: monaco.editor.IStandaloneCodeEditor;
@@ -51,7 +53,7 @@ class MonacoEditor extends React.Component<MonacoEditorProps> {
   }
 
   componentDidUpdate(prevProps: MonacoEditorProps) {
-    const { value, language, theme, height, options, width } = this.props;
+    const { value, language, theme, height, options, width, className } = this.props;
 
     const { editor } = this;
     const model = editor.getModel();
@@ -83,10 +85,14 @@ class MonacoEditor extends React.Component<MonacoEditorProps> {
       editor.layout();
     }
     if (prevProps.options !== options) {
+      const prependedOptions: monaco.editor.IStandaloneEditorConstructionOptions = {};
+      if (className) {
+        prependedOptions.extraEditorClassName = className;
+      }
       // Don't pass in the model on update because monaco crashes if we pass the model
       // a second time. See https://github.com/microsoft/monaco-editor/issues/2027
       const { model: _model, ...optionsWithoutModel } = options;
-      editor.updateOptions(optionsWithoutModel);
+      editor.updateOptions({ ...prependedOptions, ...optionsWithoutModel });
     }
   }
 
@@ -114,15 +120,20 @@ class MonacoEditor extends React.Component<MonacoEditorProps> {
   initMonaco() {
     const value =
       this.props.value != null ? this.props.value : this.props.defaultValue;
-    const { language, theme, overrideServices } = this.props;
+    const { language, theme, overrideServices, className } = this.props;
     if (this.containerElement) {
       // Before initializing monaco editor
+      const prependedOptions: monaco.editor.IStandaloneEditorConstructionOptions = {};
+      if (className) {
+        prependedOptions.extraEditorClassName = className;
+      }
       const options = { ...this.props.options, ...this.editorWillMount() };
       this.editor = monaco.editor.create(
         this.containerElement,
         {
           value,
           language,
+          ...prependedOptions,
           ...options,
           ...(theme ? { theme } : {}),
         },

--- a/src/types.ts
+++ b/src/types.ts
@@ -50,6 +50,11 @@ export interface MonacoEditorBaseProps {
    * You can create custom themes via `monaco.editor.defineTheme`.
    */
   theme?: string | null;
+
+  /**
+   * Optional string classname to append to the editor.
+   */
+  className?: string | null;
 }
 
 export interface MonacoEditorProps extends MonacoEditorBaseProps {


### PR DESCRIPTION
ref https://github.com/react-monaco-editor/react-monaco-editor/issues/319

Allows for a `className` prop on the editor, and diff editor, which then bubbles into `options. extraEditorClassName`

If `options. extraEditorClassName` were also set, that will override the `className` prop, making this backwards-compatible.

To test this, I built the lib, copied it into `examples/node_modules/react-monaco-editor/lib`, then modified my local example to add `className="an-extra-class-here"`, and verified it showed up in the inspector.

```jsx
<MonacoEditor
  height="400"
  language="javascript"
  className="an-extra-class-here"
  value={code}
  options={options}
  onChange={this.onChange}
  editorDidMount={this.editorDidMount}
  theme={theme}
/>
```

<img width="1243" alt="Screenshot_3_15_21__10_03_AM" src="https://user-images.githubusercontent.com/52420/111174744-ade3fe00-8575-11eb-937a-a7584193189c.png">
