### PR TITLE
Update `peerDependencies` to allow React v17 and v18

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,9 +49,9 @@
     "typescript": "^4.6.3"
   },
   "peerDependencies": {
-    "@types/react": "^17.x",
+    "@types/react": ">=17 <= 18",
     "monaco-editor": "^0.33.0",
-    "react": "^17.x"
+    "react": ">=17 <= 18"
   },
   "dependencies": {
     "prop-types": "^15.8.1"


### PR DESCRIPTION
This will prevent "unmet peer" warnings for projects using React v18. I'm thinking we should allow this since the example within the repo is using React v18.