### PR TITLE
fixed issue of initializing editor multiple times

### DIFF
--- a/src/diff.tsx
+++ b/src/diff.tsx
@@ -1,6 +1,6 @@
 import * as monaco from "monaco-editor/esm/vs/editor/editor.api";
 import * as React from "react";
-import { useCallback, useEffect, useMemo, useRef } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import { MonacoDiffEditorProps } from "./types";
 import { noop, processSize } from "./utils";
 
@@ -40,12 +40,12 @@ function MonacoDiffEditor({
     [fixedWidth, fixedHeight]
   );
 
-  const handleEditorWillMount = useCallback(() => {
+  const handleEditorWillMount = () => {
     const finalOptions = editorWillMount(monaco);
     return finalOptions || {};
-  }, [editorWillMount]);
+  };
 
-  const handleEditorDidMount = useCallback(() => {
+  const handleEditorDidMount = () => {
     editorDidMount(editor.current, monaco);
 
     const { modified } = editor.current.getModel();
@@ -54,13 +54,13 @@ function MonacoDiffEditor({
         onChange(modified.getValue(), event);
       }
     });
-  }, [editorDidMount, onChange]);
+  };
 
-  const handleEditorWillUnmount = useCallback(() => {
+  const handleEditorWillUnmount = () => {
     editorWillUnmount(editor.current, monaco);
-  }, [editorWillUnmount]);
+  };
 
-  const initModels = useCallback(() => {
+  const initModels = () => {
     const finalValue = value != null ? value : defaultValue;
     const originalModel = monaco.editor.createModel(original, language);
     const modifiedModel = monaco.editor.createModel(finalValue, language);
@@ -68,7 +68,7 @@ function MonacoDiffEditor({
       original: originalModel,
       modified: modifiedModel,
     });
-  }, [defaultValue, language, original, value]);
+  };
 
   useEffect(() => {
     if (containerElement.current) {
@@ -87,15 +87,7 @@ function MonacoDiffEditor({
       initModels();
       handleEditorDidMount();
     }
-  }, [
-    className,
-    handleEditorDidMount,
-    handleEditorWillMount,
-    initModels,
-    options,
-    overrideServices,
-    theme,
-  ]);
+  }, []);
 
   useEffect(() => {
     if (editor.current) {
@@ -174,7 +166,7 @@ function MonacoDiffEditor({
         _subscription.current.dispose();
       }
     },
-    [handleEditorWillUnmount]
+    []
   );
 
   return (

--- a/src/diff.tsx
+++ b/src/diff.tsx
@@ -70,24 +70,28 @@ function MonacoDiffEditor({
     });
   };
 
-  useEffect(() => {
-    if (containerElement.current) {
-      // Before initializing monaco editor
-      handleEditorWillMount();
-      editor.current = monaco.editor.createDiffEditor(
-        containerElement.current,
-        {
-          ...(className ? { extraEditorClassName: className } : {}),
-          ...options,
-          ...(theme ? { theme } : {}),
-        },
-        overrideServices
-      );
-      // After initializing monaco editor
-      initModels();
-      handleEditorDidMount();
-    }
-  }, []);
+  useEffect(
+    () => {
+      if (containerElement.current) {
+        // Before initializing monaco editor
+        handleEditorWillMount();
+        editor.current = monaco.editor.createDiffEditor(
+          containerElement.current,
+          {
+            ...(className ? { extraEditorClassName: className } : {}),
+            ...options,
+            ...(theme ? { theme } : {}),
+          },
+          overrideServices
+        );
+        // After initializing monaco editor
+        initModels();
+        handleEditorDidMount();
+      }
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  );
 
   useEffect(() => {
     if (editor.current) {
@@ -166,6 +170,7 @@ function MonacoDiffEditor({
         _subscription.current.dispose();
       }
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     []
   );
 

--- a/src/editor.tsx
+++ b/src/editor.tsx
@@ -1,6 +1,6 @@
 import * as monaco from "monaco-editor/esm/vs/editor/editor.api";
 import * as React from "react";
-import { useCallback, useEffect, useMemo, useRef } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import { MonacoEditorProps } from "./types";
 import { noop, processSize } from "./utils";
 
@@ -39,12 +39,12 @@ function MonacoEditor({
     [fixedWidth, fixedHeight]
   );
 
-  const handleEditorWillMount = useCallback(() => {
+  const handleEditorWillMount = () => {
     const finalOptions = editorWillMount(monaco);
     return finalOptions || {};
-  }, [editorWillMount]);
+  };
 
-  const handleEditorDidMount = useCallback(() => {
+  const handleEditorDidMount = () => {
     editorDidMount(editor.current, monaco);
 
     _subscription.current = editor.current.onDidChangeModelContent((event) => {
@@ -52,13 +52,13 @@ function MonacoEditor({
         onChange(editor.current.getValue(), event);
       }
     });
-  }, [editorDidMount, onChange]);
+  };
 
-  const handleEditorWillUnmount = useCallback(() => {
+  const handleEditorWillUnmount = () => {
     editorWillUnmount(editor.current, monaco);
-  }, [editorWillUnmount]);
+  };
 
-  const initMonaco = useCallback(() => {
+  const initMonaco = () => {
     const finalValue = value !== null ? value : defaultValue;
     if (containerElement.current) {
       // Before initializing monaco editor
@@ -77,21 +77,9 @@ function MonacoEditor({
       // After initializing monaco editor
       handleEditorDidMount();
     }
-  }, [
-    className,
-    defaultValue,
-    handleEditorDidMount,
-    handleEditorWillMount,
-    language,
-    options,
-    overrideServices,
-    theme,
-    value,
-  ]);
+  };
 
-  useEffect(() => {
-    initMonaco();
-  }, [initMonaco]);
+  useEffect(initMonaco, []);
 
   useEffect(() => {
     if (editor.current) {
@@ -157,7 +145,7 @@ function MonacoEditor({
         _subscription.current.dispose();
       }
     },
-    [handleEditorWillUnmount]
+    []
   );
 
   return (

--- a/src/editor.tsx
+++ b/src/editor.tsx
@@ -79,6 +79,7 @@ function MonacoEditor({
     }
   };
 
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(initMonaco, []);
 
   useEffect(() => {
@@ -145,6 +146,7 @@ function MonacoEditor({
         _subscription.current.dispose();
       }
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     []
   );
 


### PR DESCRIPTION
It fixes #655, also addresses #640.

The fix is to initialize the editor (by`initMonaco`) only when the component is mounted, and dispose the editor only before it's unmounted, as the props updating is already handled by perspective side effects.