### PR TITLE
Allow a wider version range for React

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,9 +49,9 @@
     "typescript": "^4.9.3"
   },
   "peerDependencies": {
-    "@types/react": ">=17 <= 18",
+    "@types/react": ">=16 <= 18",
     "monaco-editor": "^0.34.1",
-    "react": ">=17 <= 18"
+    "react": ">=16 <= 18"
   },
   "dependencies": {
     "prop-types": "^15.8.1"


### PR DESCRIPTION
Noticed this peer dep error:

```
❯ yarn explain peer-requirements pe94ca
➤ YN0000: studio@workspace:packages/studio provides react@npm:16.14.0 with version 16.14.0, which doesn't satisfy the following requirements:
➤ YN0000: @org/dashboard-editors@npm:25.1.0     → ^16.11.0 ✓
➤ YN0000: @org/dynamic-editors@npm:0.21.5       → ^16.11.0 ✓
➤ YN0000: @org/react-search@npm:4.0.1           → ^16.8    ✓
➤ YN0000: @org/react-time-range@npm:8.1.0       → ^16.10.0 ✓
➤ YN0000: @org/themes@npm:0.12.0                → ^16.8    ✓
➤ YN0000: @org/themes@npm:0.7.0                 → ^16.8    ✓
➤ YN0000: react-mde@npm:11.5.0                  → ^17.0.0  ✘
➤ YN0000: react-monaco-editor@npm:0.45.0        → ^17.x    ✘
```

I've been using `react-monaco-editor` for a long time on React 16 and haven't had any errors. I've just been ignoring the yarn warning. I believe there's no breaking changes from React 16 to 17, so it should be safe to widen this range to allow 16.
