### PR TITLE
fix: Don't set the Monaco value if it hasn't changed

### DIFF
--- a/src/editor.tsx
+++ b/src/editor.tsx
@@ -84,6 +84,10 @@ function MonacoEditor({
 
   useEffect(() => {
     if (editor.current) {
+      if (value === editor.current.getValue()) {
+        return;
+      }
+
       const model = editor.current.getModel();
       __prevent_trigger_change_event.current = true;
       editor.current.pushUndoStop();


### PR DESCRIPTION
This avoids a flicker caused by Monaco needlessly resetting the content and performing syntax highlighting again.

Fixes #689