### PR TITLE
Feat: add editor optional URI prop

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -83,9 +83,7 @@ class AnotherEditor extends React.Component {
   constructor() {
     super();
     this.state = {
-      code: ["{", '    "$schema": "http://myserver/foo-schema.json"', "}"].join(
-        "\n"
-      ),
+      code: ["{", '    "$schema": "http://myserver/foo-schema.json"', "}"].join("\n"),
       language: "json",
     };
   }
@@ -157,6 +155,83 @@ class AnotherEditor extends React.Component {
   }
 }
 
+class CodeEditorWithUri extends React.Component {
+  constructor() {
+    super();
+    this.state = {
+      code: `{\n"p1": "v3",\n"q1": "Value"\n}`,
+    };
+  }
+
+  editorWillMount = (monaco) => {
+    monaco.languages.json.jsonDefaults.setDiagnosticsOptions({
+      validate: true,
+      schemas: [
+        {
+          uri: "http://myserver/foo-schema.json",
+          fileMatch: ["file:///test-editor-with-validation"],
+          schema: {
+            type: "object",
+            properties: {
+              p1: {
+                enum: ["v1", "v2"],
+              },
+              p2: {
+                $ref: "http://myserver/bar-schema.json",
+              },
+            },
+          },
+        },
+        {
+          uri: "http://myserver/bar-schema.json",
+          fileMatch: ["file:///test-editor-with-validation"],
+          schema: {
+            type: "object",
+            properties: {
+              q1: {
+                enum: ["x1", "x2"],
+              },
+            },
+          },
+        },
+      ],
+    });
+  };
+
+  render() {
+    const { code } = this.state;
+    const options = {
+      selectOnLineNumbers: true,
+      roundedSelection: false,
+      readOnly: false,
+      cursorStyle: "line",
+      automaticLayout: false,
+    };
+    return (
+      <div>
+        <MonacoEditor
+          height="400"
+          language="json"
+          value={code}
+          options={options}
+          onChange={this.onChange}
+          editorWillMount={this.editorWillMount}
+          uri={({ Uri }) => Uri.parse("test-editor")}
+        />
+        <MonacoEditor
+          height="400"
+          language="json"
+          value={code}
+          options={options}
+          onChange={this.onChange}
+          editorWillMount={this.editorWillMount}
+          uri={({ Uri }) => Uri.parse("test-editor-with-validation")}
+        />
+      </div>
+    );
+  }
+}
+
 class DiffEditor extends React.Component {
   constructor() {
     super();
@@ -198,6 +273,9 @@ const App = () => (
     <hr />
     <h2>Another editor (uncontrolled mode)</h2>
     <AnotherEditor />
+    <hr />
+    <h2>Editor with specific URI</h2>
+    <CodeEditorWithUri />
     <hr />
     <h2>Another editor (showing a diff)</h2>
     <DiffEditor />

--- a/src/diff.tsx
+++ b/src/diff.tsx
@@ -19,6 +19,8 @@ function MonacoDiffEditor({
   onChange,
   className,
   original,
+  originalUri,
+  modifiedUri,
 }: MonacoDiffEditorProps) {
   const containerElement = useRef<HTMLDivElement | null>(null);
 
@@ -62,8 +64,34 @@ function MonacoDiffEditor({
 
   const initModels = () => {
     const finalValue = value != null ? value : defaultValue;
-    const originalModel = monaco.editor.createModel(original, language);
-    const modifiedModel = monaco.editor.createModel(finalValue, language);
+    const originalModelUri = originalUri?.(monaco);
+    const modifiedModelUri = modifiedUri?.(monaco);
+    let originalModel = monaco.editor.getModel(originalModelUri);
+    let modifiedModel = monaco.editor.getModel(modifiedModelUri);
+
+    // Cannot create two models with the same URI,
+    // if model with the given URI is already created, just update it.
+    if (originalModel) {
+      originalModel.setValue(original);
+      monaco.editor.setModelLanguage(originalModel, language);
+    } else {
+      originalModel = monaco.editor.createModel(
+        finalValue,
+        language,
+        originalModelUri
+      );
+    }
+    if (modifiedModel) {
+      originalModel.setValue(finalValue);
+      monaco.editor.setModelLanguage(modifiedModel, language);
+    } else {
+      modifiedModel = monaco.editor.createModel(
+        finalValue,
+        language,
+        modifiedModelUri
+      );
+    }
+
     editor.current.setModel({
       original: originalModel,
       modified: modifiedModel,

--- a/src/diff.tsx
+++ b/src/diff.tsx
@@ -66,8 +66,10 @@ function MonacoDiffEditor({
     const finalValue = value != null ? value : defaultValue;
     const originalModelUri = originalUri?.(monaco);
     const modifiedModelUri = modifiedUri?.(monaco);
-    let originalModel = monaco.editor.getModel(originalModelUri);
-    let modifiedModel = monaco.editor.getModel(modifiedModelUri);
+    let originalModel =
+      originalModelUri && monaco.editor.getModel(originalModelUri);
+    let modifiedModel =
+      modifiedModelUri && monaco.editor.getModel(modifiedModelUri);
 
     // Cannot create two models with the same URI,
     // if model with the given URI is already created, just update it.

--- a/src/editor.tsx
+++ b/src/editor.tsx
@@ -18,6 +18,7 @@ function MonacoEditor({
   editorWillUnmount,
   onChange,
   className,
+  uri,
 }: MonacoEditorProps) {
   const containerElement = useRef<HTMLDivElement | null>(null);
 
@@ -63,11 +64,11 @@ function MonacoEditor({
     if (containerElement.current) {
       // Before initializing monaco editor
       const finalOptions = { ...options, ...handleEditorWillMount() };
+      const model = monaco.editor.createModel(finalValue, language, uri);
       editor.current = monaco.editor.create(
         containerElement.current,
         {
-          value: finalValue,
-          language,
+          model,
           ...(className ? { extraEditorClassName: className } : {}),
           ...finalOptions,
           ...(theme ? { theme } : {}),

--- a/src/editor.tsx
+++ b/src/editor.tsx
@@ -61,10 +61,20 @@ function MonacoEditor({
 
   const initMonaco = () => {
     const finalValue = value !== null ? value : defaultValue;
+
     if (containerElement.current) {
       // Before initializing monaco editor
       const finalOptions = { ...options, ...handleEditorWillMount() };
-      const model = monaco.editor.createModel(finalValue, language, uri);
+      const modelUri = uri?.(monaco);
+      let model = monaco.editor.getModel(modelUri);
+      if (model) {
+        // Cannot create two models with the same URI,
+        // if model with the given URI is already created, just update it.
+        model.setValue(finalValue);
+        monaco.editor.setModelLanguage(model, language);
+      } else {
+        model = monaco.editor.createModel(finalValue, language, modelUri);
+      }
       editor.current = monaco.editor.create(
         containerElement.current,
         {
@@ -142,6 +152,7 @@ function MonacoEditor({
       if (editor.current) {
         handleEditorWillUnmount();
         editor.current.dispose();
+
         const model = editor.current.getModel();
         if (model) {
           model.dispose();

--- a/src/editor.tsx
+++ b/src/editor.tsx
@@ -66,7 +66,7 @@ function MonacoEditor({
       // Before initializing monaco editor
       const finalOptions = { ...options, ...handleEditorWillMount() };
       const modelUri = uri?.(monaco);
-      let model = monaco.editor.getModel(modelUri);
+      let model = modelUri && monaco.editor.getModel(modelUri);
       if (model) {
         // Cannot create two models with the same URI,
         // if model with the given URI is already created, just update it.

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,28 +5,18 @@ import * as monacoEditor from "monaco-editor/esm/vs/editor/editor.api";
  * This will be `IStandaloneEditorConstructionOptions` in newer versions of monaco-editor, or
  * `IEditorConstructionOptions` in versions before that was introduced.
  */
-export type EditorConstructionOptions = NonNullable<
-  Parameters<typeof monacoEditor.editor.create>[1]
->;
+export type EditorConstructionOptions = NonNullable<Parameters<typeof monacoEditor.editor.create>[1]>;
 
-export type EditorWillMount = (
-  monaco: typeof monacoEditor
-) => void | EditorConstructionOptions;
+export type EditorWillMount = (monaco: typeof monacoEditor) => void | EditorConstructionOptions;
 
-export type EditorDidMount = (
-  editor: monacoEditor.editor.IStandaloneCodeEditor,
-  monaco: typeof monacoEditor
-) => void;
+export type EditorDidMount = (editor: monacoEditor.editor.IStandaloneCodeEditor, monaco: typeof monacoEditor) => void;
 
 export type EditorWillUnmount = (
   editor: monacoEditor.editor.IStandaloneCodeEditor,
   monaco: typeof monacoEditor
 ) => void | EditorConstructionOptions;
 
-export type ChangeHandler = (
-  value: string,
-  event: monacoEditor.editor.IModelContentChangedEvent
-) => void;
+export type ChangeHandler = (value: string, event: monacoEditor.editor.IModelContentChangedEvent) => void;
 
 export interface MonacoEditorBaseProps {
   /**
@@ -100,7 +90,10 @@ export interface MonacoEditorProps extends MonacoEditorBaseProps {
    */
   onChange?: ChangeHandler;
 
-  uri?: monacoEditor.Uri;
+  /**
+   * let the language be inferred from the uri
+   */
+  uri?: (monaco: typeof monacoEditor) => monacoEditor.Uri;
 }
 
 // ============ Diff Editor ============
@@ -162,4 +155,14 @@ export interface MonacoDiffEditorProps extends MonacoEditorBaseProps {
    * An event emitted when the content of the current model has changed.
    */
   onChange?: DiffChangeHandler;
+
+  /**
+   * let the language be inferred from the uri
+   */
+  originalUri?: (monaco: typeof monacoEditor) => monacoEditor.Uri;
+
+  /**
+   * let the language be inferred from the uri
+   */
+  modifiedUri?: (monaco: typeof monacoEditor) => monacoEditor.Uri;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,18 +5,28 @@ import * as monacoEditor from "monaco-editor/esm/vs/editor/editor.api";
  * This will be `IStandaloneEditorConstructionOptions` in newer versions of monaco-editor, or
  * `IEditorConstructionOptions` in versions before that was introduced.
  */
-export type EditorConstructionOptions = NonNullable<Parameters<typeof monacoEditor.editor.create>[1]>;
+export type EditorConstructionOptions = NonNullable<
+  Parameters<typeof monacoEditor.editor.create>[1]
+>;
 
-export type EditorWillMount = (monaco: typeof monacoEditor) => void | EditorConstructionOptions;
+export type EditorWillMount = (
+  monaco: typeof monacoEditor
+) => void | EditorConstructionOptions;
 
-export type EditorDidMount = (editor: monacoEditor.editor.IStandaloneCodeEditor, monaco: typeof monacoEditor) => void;
+export type EditorDidMount = (
+  editor: monacoEditor.editor.IStandaloneCodeEditor,
+  monaco: typeof monacoEditor
+) => void;
 
 export type EditorWillUnmount = (
   editor: monacoEditor.editor.IStandaloneCodeEditor,
   monaco: typeof monacoEditor
 ) => void | EditorConstructionOptions;
 
-export type ChangeHandler = (value: string, event: monacoEditor.editor.IModelContentChangedEvent) => void;
+export type ChangeHandler = (
+  value: string,
+  event: monacoEditor.editor.IModelContentChangedEvent
+) => void;
 
 export interface MonacoEditorBaseProps {
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -99,6 +99,8 @@ export interface MonacoEditorProps extends MonacoEditorBaseProps {
    * An event emitted when the content of the current model has changed.
    */
   onChange?: ChangeHandler;
+
+  uri?: monacoEditor.Uri;
 }
 
 // ============ Diff Editor ============

--- a/src/types.ts
+++ b/src/types.ts
@@ -101,7 +101,7 @@ export interface MonacoEditorProps extends MonacoEditorBaseProps {
   onChange?: ChangeHandler;
 
   /**
-   * let the language be inferred from the uri
+   * Let the language be inferred from the uri
    */
   uri?: (monaco: typeof monacoEditor) => monacoEditor.Uri;
 }
@@ -167,12 +167,12 @@ export interface MonacoDiffEditorProps extends MonacoEditorBaseProps {
   onChange?: DiffChangeHandler;
 
   /**
-   * let the language be inferred from the uri
+   * Let the language be inferred from the uri
    */
   originalUri?: (monaco: typeof monacoEditor) => monacoEditor.Uri;
 
   /**
-   * let the language be inferred from the uri
+   * Let the language be inferred from the uri
    */
   modifiedUri?: (monaco: typeof monacoEditor) => monacoEditor.Uri;
 }


### PR DESCRIPTION
According to multiple issues related to the demanding feature for setting the editor URI from React component: #337 #324 #270 #67 #31.

## Problem
React component do not let user set the editor model URI, and setting that after model creation is not possible.

## Workaround
I added a prop named `uri` that accepts a function, this function gives user `monaco: typeof monacoEditor`, so user can parse the path like the example below:

```jsx
<MonacoEditor
    height="400"
    language="json"
    value={code}
    options={options}
    uri={({ Uri }) => Uri.parse("test-editor")}
/>
```

### The Challenge
The issue I had was creating a model with the same URI multiple times, so after the first time you would get the error. I solved this by checking if Monaco has any model created with that URI and instead of creating a new model, trying to update the existing model.
Now if you even change the `key` of your `<MonacoEditor />` component with the same value passed for URI, you will not get the error and your editor's model just gets the value and language updates.

I have tested the solution for editor, diff editor and also updated the examples. 
Thanks for considering the PR @domoritz @superRaytin 