### PR TITLE
Remove explicit model deletion

### DIFF
--- a/src/editor.tsx
+++ b/src/editor.tsx
@@ -152,11 +152,6 @@ function MonacoEditor({
       if (editor.current) {
         handleEditorWillUnmount();
         editor.current.dispose();
-
-        const model = editor.current.getModel();
-        if (model) {
-          model.dispose();
-        }
       }
       if (_subscription.current) {
         _subscription.current.dispose();


### PR DESCRIPTION
This PR removes explicit model deletion during unmounting.

Conceptually `IDisposable` cleans up everything within the object. Since the current code invokes `getModel` after `dispose`, there may be no guarantee to work.
At the implementation level, [`StandaloneEditor.dispose` eventually detaches the model (with invocation of the model's `dispose`)](https://github.com/microsoft/vscode/blob/3b60c12380f5a9782439be309d8d2642835b8822/src/vs/editor/browser/widget/codeEditorWidget.ts#L427) and the `getModel` here will return `null` every time.
