### PR TITLE
fix: stale onChange callback in onDidChangeModelContent handler

### DIFF
--- a/src/editor.tsx
+++ b/src/editor.tsx
@@ -2,7 +2,7 @@ import * as monaco from "monaco-editor/esm/vs/editor/editor.api";
 import * as React from "react";
 import { useEffect, useMemo, useRef } from "react";
 import { MonacoEditorProps } from "./types";
-import { noop, processSize } from "./utils";
+import { noop, processSize, propCallbacks } from "./utils";
 
 function MonacoEditor({
   width,
@@ -32,6 +32,8 @@ function MonacoEditor({
 
   const fixedHeight = processSize(height);
 
+  propCallbacks.onChange = onChange;
+
   const style = useMemo(
     () => ({
       width: fixedWidth,
@@ -50,7 +52,7 @@ function MonacoEditor({
 
     _subscription.current = editor.current.onDidChangeModelContent((event) => {
       if (!__prevent_trigger_change_event.current) {
-        onChange(editor.current.getValue(), event);
+        propCallbacks.onChange?.(editor.current.getValue(), event);
       }
     });
   };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,11 @@
+import { MonacoEditorProps } from "./types";
+
 export function processSize(size: number | string) {
   return !/^\d+$/.test(size as string) ? size : `${size}px`;
 }
 
 export function noop() {}
+
+export const propCallbacks: Pick<MonacoEditorProps, "onChange"> = {
+  onChange: null,
+};


### PR DESCRIPTION
Hi ! This is my first PR here. I am a front-end software developer. In the project I am currently working in we are using `react-monaco-editor` and noticed this behaviour. I employed this technique to pass in the latest reference of the onChange function without using any hooks.

Re-initializing `onDidChangeModelContent` doesn't seem necessary here every time onChange ref changes from the props since most people define handlers inside the render body itself. 

Fixes https://github.com/react-monaco-editor/react-monaco-editor/issues/704