### PR TITLE
Add Them union type and activate partial autocomplete for it

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -54,7 +54,7 @@ export interface MonacoEditorBaseProps {
    * The current out-of-the-box available themes are: 'vs' (default), 'vs-dark', 'hc-black'.
    * You can create custom themes via `monaco.editor.defineTheme`.
    */
-  theme?: string | null;
+  theme?:Theme | (string & {}) | null;
 
   /**
    * Optional string classname to append to the editor.
@@ -176,3 +176,6 @@ export interface MonacoDiffEditorProps extends MonacoEditorBaseProps {
    */
   modifiedUri?: (monaco: typeof monacoEditor) => monacoEditor.Uri;
 }
+
+// Default themes
+export type Theme = 'vs' |'vs-dark' | 'hc-black';

--- a/src/types.ts
+++ b/src/types.ts
@@ -54,7 +54,7 @@ export interface MonacoEditorBaseProps {
    * The current out-of-the-box available themes are: 'vs' (default), 'vs-dark', 'hc-black'.
    * You can create custom themes via `monaco.editor.defineTheme`.
    */
-  theme?:Theme | (string & {}) | null;
+  theme?: Theme | (string & NonNullable<unknown>) | null;
 
   /**
    * Optional string classname to append to the editor.
@@ -178,4 +178,4 @@ export interface MonacoDiffEditorProps extends MonacoEditorBaseProps {
 }
 
 // Default themes
-export type Theme = 'vs' |'vs-dark' | 'hc-black';
+export type Theme = "vs" | "vs-dark" | "hc-black";


### PR DESCRIPTION
In "src\types.ts" file, I defined a type named "Them" as union " 'vs' |'vs-dark' | 'hc-black' ". 
I changed "them" in MonacoEditorBaseProps interface to "theme?:Theme | (string & {}) | null;" so now we can have partial autocomplete and TypeScript provide us  'vs' |'vs-dark' | 'hc-black' autocomplete and allows any other string.