### PR TITLE
fix: using wrong onChange if multiple instances of monaco editor are mounted on the same screen

### DIFF
--- a/src/editor.tsx
+++ b/src/editor.tsx
@@ -2,7 +2,7 @@ import * as monaco from "monaco-editor/esm/vs/editor/editor.api";
 import * as React from "react";
 import { useEffect, useMemo, useRef } from "react";
 import { MonacoEditorProps } from "./types";
-import { noop, processSize, propCallbacks } from "./utils";
+import { noop, processSize } from "./utils";
 
 function MonacoEditor({
   width,
@@ -32,7 +32,8 @@ function MonacoEditor({
 
   const fixedHeight = processSize(height);
 
-  propCallbacks.onChange = onChange;
+  const onChangeRef = useRef(onChange);
+  onChangeRef.current = onChange;
 
   const style = useMemo(
     () => ({
@@ -52,7 +53,7 @@ function MonacoEditor({
 
     _subscription.current = editor.current.onDidChangeModelContent((event) => {
       if (!__prevent_trigger_change_event.current) {
-        propCallbacks.onChange?.(editor.current.getValue(), event);
+        onChangeRef.current?.(editor.current.getValue(), event);
       }
     });
   };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,11 +1,5 @@
-import { MonacoEditorProps } from "./types";
-
 export function processSize(size: number | string) {
   return !/^\d+$/.test(size as string) ? size : `${size}px`;
 }
 
 export function noop() {}
-
-export const propCallbacks: Pick<MonacoEditorProps, "onChange"> = {
-  onChange: null,
-};


### PR DESCRIPTION
While tackling the problem of stale onChange callback, onChange was hooked into a global variable. And on each re-render this global variable was updated with the latest reference of the onChange. But this should have been through a ref object instead. This way individual MonacoEditor components will have their own references of onChange. 

Although React warns against writing to ref during renders this is safe since we are not using the ref in the rendering logic.

Fixes https://github.com/react-monaco-editor/react-monaco-editor/issues/964