### PR TITLE
Support refs for interacting with the MonacoEditor instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,9 +157,15 @@ Make sure to use the [Monaco Webpack plugin](https://github.com/Microsoft/monaco
 
 ### How to interact with the MonacoEditor instance
 
-Using the first parameter of `editorDidMount`, or using a `ref` (e.g. `<MonacoEditor ref="monaco">`) after `editorDidMount` event has fired.
+Using the first parameter of `editorDidMount`, or using a `ref` (e.g. `<MonacoEditor ref={monacoEditorRef}>`).
 
-Then you can invoke instance methods via `this.refs.monaco.editor`, e.g. `this.refs.monaco.editor.focus()` to focuses the MonacoEditor instance.
+```js
+const monacoEditorRef = useRef(null);
+return (<>
+  <button onClick={() => monacoEditorRef.current.editor.focus()}>Focus</button>
+  <MonacoEditor ref={monacoEditorRef} />
+</>)
+```
 
 ### How to get value of editor
 

--- a/package.json
+++ b/package.json
@@ -53,5 +53,6 @@
     "monaco-editor": "^0.52.0",
     "react": ">=16.8.0 <20.0.0",
     "react-dom": ">=16.8.0 <20.0.0"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/package.json
+++ b/package.json
@@ -53,6 +53,5 @@
     "monaco-editor": "^0.52.0",
     "react": ">=16.8.0 <20.0.0",
     "react-dom": ">=16.8.0 <20.0.0"
-  },
-  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
+  }
 }

--- a/src/diff.tsx
+++ b/src/diff.tsx
@@ -1,27 +1,30 @@
 import * as monaco from "monaco-editor/esm/vs/editor/editor.api";
 import * as React from "react";
 import { useEffect, useMemo, useRef } from "react";
-import { MonacoDiffEditorProps } from "./types";
+import { MonacoDiffEditorHandle, MonacoDiffEditorProps } from "./types";
 import { noop, processSize } from "./utils";
 
-function MonacoDiffEditor({
-  width = "100%",
-  height = "100%",
-  value = null,
-  defaultValue = "",
-  language = "javascript",
-  theme = null,
-  options = {},
-  overrideServices = {},
-  editorWillMount = noop,
-  editorDidMount = noop,
-  editorWillUnmount = noop,
-  onChange = noop,
-  className = null,
-  original = null,
-  originalUri,
-  modifiedUri,
-}: MonacoDiffEditorProps) {
+function MonacoDiffEditor(
+  {
+    width = "100%",
+    height = "100%",
+    value = null,
+    defaultValue = "",
+    language = "javascript",
+    theme = null,
+    options = {},
+    overrideServices = {},
+    editorWillMount = noop,
+    editorDidMount = noop,
+    editorWillUnmount = noop,
+    onChange = noop,
+    className = null,
+    original = null,
+    originalUri,
+    modifiedUri,
+  }: MonacoDiffEditorProps,
+  ref: React.ForwardedRef<MonacoDiffEditorHandle>,
+) {
   const containerElement = useRef<HTMLDivElement | null>(null);
 
   const editor = useRef<monaco.editor.IStandaloneDiffEditor | null>(null);
@@ -41,6 +44,12 @@ function MonacoDiffEditor({
     }),
     [fixedWidth, fixedHeight],
   );
+
+  React.useImperativeHandle(ref, () => ({
+    get editor() {
+      return editor.current;
+    },
+  }));
 
   const handleEditorWillMount = () => {
     const finalOptions = editorWillMount(monaco);
@@ -213,6 +222,8 @@ function MonacoDiffEditor({
   );
 }
 
-MonacoDiffEditor.displayName = "MonacoDiffEditor";
+const MonacoDiffEditorForwarded = React.forwardRef(MonacoDiffEditor);
 
-export default MonacoDiffEditor;
+MonacoDiffEditorForwarded.displayName = "MonacoDiffEditor";
+
+export default MonacoDiffEditorForwarded;

--- a/src/editor.tsx
+++ b/src/editor.tsx
@@ -1,25 +1,28 @@
 import * as monaco from "monaco-editor/esm/vs/editor/editor.api";
 import * as React from "react";
 import { useEffect, useMemo, useRef } from "react";
-import { MonacoEditorProps } from "./types";
+import { MonacoEditorHandle, MonacoEditorProps } from "./types";
 import { noop, processSize } from "./utils";
 
-function MonacoEditor({
-  width = "100%",
-  height = "100%",
-  value = null,
-  defaultValue = "",
-  language = "javascript",
-  theme = null,
-  options = {},
-  overrideServices = {},
-  editorWillMount = noop,
-  editorDidMount = noop,
-  editorWillUnmount = noop,
-  onChange = noop,
-  className = null,
-  uri,
-}: MonacoEditorProps) {
+function MonacoEditor(
+  {
+    width = "100%",
+    height = "100%",
+    value = null,
+    defaultValue = "",
+    language = "javascript",
+    theme = null,
+    options = {},
+    overrideServices = {},
+    editorWillMount = noop,
+    editorDidMount = noop,
+    editorWillUnmount = noop,
+    onChange = noop,
+    className = null,
+    uri,
+  }: MonacoEditorProps,
+  ref: React.ForwardedRef<MonacoEditorHandle>,
+) {
   const containerElement = useRef<HTMLDivElement | null>(null);
 
   const editor = useRef<monaco.editor.IStandaloneCodeEditor | null>(null);
@@ -34,6 +37,12 @@ function MonacoEditor({
 
   const onChangeRef = useRef(onChange);
   onChangeRef.current = onChange;
+
+  React.useImperativeHandle(ref, () => ({
+    get editor() {
+      return editor.current;
+    },
+  }));
 
   const style = useMemo(
     () => ({
@@ -173,6 +182,7 @@ function MonacoEditor({
   );
 }
 
-MonacoEditor.displayName = "MonacoEditor";
+const MonacoEditorForwarded = React.forwardRef(MonacoEditor);
+MonacoEditorForwarded.displayName = "MonacoEditor";
 
-export default MonacoEditor;
+export default MonacoEditorForwarded;

--- a/src/types.ts
+++ b/src/types.ts
@@ -179,3 +179,11 @@ export interface MonacoDiffEditorProps extends MonacoEditorBaseProps {
 
 // Default themes
 export type Theme = "vs" | "vs-dark" | "hc-black";
+
+export interface MonacoEditorHandle {
+  editor: monacoEditor.editor.IStandaloneCodeEditor;
+}
+
+export interface MonacoDiffEditorHandle {
+  editor: monacoEditor.editor.IStandaloneDiffEditor;
+}


### PR DESCRIPTION
The change allows access to the MonacoEditor through the ref. This was mentioned in the README, but it looks like it got dropped at some point. 

The diff is better viewed with ignored whitespace. Let me know if there's anything I need to do. Thanks!